### PR TITLE
Change URF-line in XML template to 'URF=DM3'.

### DIFF
--- a/airprint-generate.py
+++ b/airprint-generate.py
@@ -55,7 +55,7 @@ XML_TEMPLATE = """<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 	<txt-record>txtvers=1</txt-record>
 	<txt-record>qtotal=1</txt-record>
 	<txt-record>Transparent=T</txt-record>
-	<txt-record>URF=none</txt-record>
+	<txt-record>URF=DM3</txt-record>
 </service>
 </service-group>"""
 


### PR DESCRIPTION
There is no discernible reason why, but this change (inspired by
https://launchpadlibrarian.net/124973715/cups_1.5.3-0ubuntu5.1_1.5.3-0ubuntu6.debdiff)
allows us to (air)print duplex on Debian Wheezy.
