### PR TITLE
[Refactor] Python3 upgrade and Docker containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /opt
+
+RUN apt update && apt install -y \
+    gcc \
+    python3 \
+    python3-pip \
+    libcups2-dev \
+    python3-dev \ 
+    python3-libxml2 \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install \
+	pycups==2.0.1
+
+COPY . ./
+
+ENTRYPOINT ["./airprint-generate.py"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-airprint-generate.py
+## airprint-generate.py
 
 This script will generate avahi .service files for shared CUPS printers.
 
@@ -17,7 +17,7 @@ are trimmed out of the list run with the script with the verbose flag (--verbose
 If python-lxml is installed, .service files will be generated in a human
 readble format, I wasn't able to get minidom's version to work acceptably.
 
-Usage: airprint-generate.py [options]
+### Usage: airprint-generate.py [options]
 
 Options:
   -h, --help            show this help message and exit
@@ -30,3 +30,19 @@ Options:
   -v, --verbose         Print debugging information to STDERR
   -p PREFIX, --prefix=PREFIX
                         Prefix all files with this string
+## Docker containerized avahi .service generation
+
+After the printers have been configured in the cups server, docker can interactively generate the avahi .service
+while making use of the container.
+
+* Build the container
+
+```shell
+docker build -t airprint-generate .
+```
+
+* Generate the avahi service by defining the ip address of the cups server
+
+```shell
+docker run --rm -it -v $(pwd):/tmp airprint-generate -H ${CUPS_SERVER_IP} -d /tmp
+```

--- a/airprint-generate.py
+++ b/airprint-generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Copyright (c) 2010 Timothy J Fontaine <tjfontaine@atxconsulting.com>
@@ -22,9 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import cups, os, optparse, re, urlparse
+import cups, os, optparse, re
+import urllib.parse as urlparse
 import os.path
-from StringIO import StringIO
+from io import StringIO
 
 from xml.dom.minidom import parseString
 from xml.dom import minidom
@@ -43,7 +44,8 @@ except:
             from elementtree import Element, ElementTree, tostring
             etree = None
         except:
-            raise 'Failed to find python libxml or elementtree, please install one of those or use python >= 2.5'
+            print('Failed to find python libxml or elementtree, please install one of those or use python >= 2.5')
+            raise
 
 XML_TEMPLATE = """<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 <service-group>
@@ -121,7 +123,7 @@ class AirPrintGenerate(object):
             
         printers = conn.getPrinters()
         
-        for p, v in printers.items():
+        for p, v in list(printers.items()):
             if v['printer-is-shared']:
                 attrs = conn.getPrinterAttributes(p)
                 uri = urlparse.urlparse(v['printer-uri-supported'])


### PR DESCRIPTION
- add support for python3
- add interactive generation of avahi service files through docker
- convert readme to markdown

No longer will you need to check for dependencies when generating the avahi service file for AirPrint

Thanks @AlexMorro for the issue https://github.com/tjfontaine/airprint-generate/issues/23

Testing methodology

- [x] Generate avahi service file
- [x] Compare with working file in the live server that was created with python2
- [x] Create VM and generate an avahi service file using python2 and compare with python3 generated file
- [x] Test print from iPhone
