### PR TITLE
Fix opening the output file in either normal or binary mode

### DIFF
--- a/airprint-generate.py
+++ b/airprint-generate.py
@@ -220,7 +220,7 @@ class AirPrintGenerate(object):
                 if self.directory:
                     fname = os.path.join(self.directory, fname)
                 
-                f = open(fname, 'w')
+                f = open(fname, 'wb' if etree else 'w')
 
                 if etree:
                     tree.write(f, pretty_print=True, xml_declaration=True, encoding="UTF-8")


### PR DESCRIPTION
Fix the etree in Python lxml wanting to have the file opened in the 'wb' mode for the write() function to work. Fixes the 'TypeError: write() argument must be str, not bytes' error message but should retain compatibility if lxml would be missing. Closes issues #26 and #28