### PR TITLE
Fix for "TypeError: write() argument must be str, not bytes" on Python 3.8+

### DIFF
--- a/airprint-generate.py
+++ b/airprint-generate.py
@@ -220,7 +220,7 @@ class AirPrintGenerate(object):
                 if self.directory:
                     fname = os.path.join(self.directory, fname)
                 
-                f = open(fname, 'w')
+                f = open(fname, 'wb')
 
                 if etree:
                     tree.write(f, pretty_print=True, xml_declaration=True, encoding="UTF-8")


### PR DESCRIPTION
As the output file is created for writing text and lxml raw generates bytes objects an error is thrown. 
Opening the file in binary mode solves the issue.